### PR TITLE
Adds markdown block support.

### DIFF
--- a/syntax.json
+++ b/syntax.json
@@ -325,5 +325,17 @@
         "pattern": ";"
       }
     ]
+  },
+  {
+    "language": "Markdown",
+    "markers": [
+      {
+        "type": "block",
+        "pattern": {
+          "start": "<!---",
+          "end": "-->"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
I have been poking around trying to determine how markdown should be supported but seems not to be. 

 On my builds I see: "Could not check autoissue/nonsense.md for TODOs as this language is not yet supported by default."
 
 I see that you download a large list of supported languages when trying to determine valid extensions, but it seems like without this addition to the syntax.json file, markdown isn't truly supported. 