### PR TITLE
add Tex (and latex) support

### DIFF
--- a/syntax.json
+++ b/syntax.json
@@ -397,5 +397,21 @@
         }
       }
     ]
+  },
+  {
+    "language": " TeX",
+    "markers": [
+      {
+        "type": "line",
+        "pattern": "%"
+      },
+      {
+        "type": "block",
+        "pattern": {
+          "start": "\begin{comment}",
+          "end": "\end{comment}"
+        }
+      }
+    ]
   }
 ]

--- a/syntax.json
+++ b/syntax.json
@@ -408,8 +408,8 @@
       {
         "type": "block",
         "pattern": {
-          "start": "\begin{comment}",
-          "end": "\end{comment}"
+          "start": "\\begin{comment}",
+          "end": "\\end{comment}"
         }
       }
     ]


### PR DESCRIPTION
Technically block comments aren't supported in the base language, but the

```
 \begin{comment} 
\end{comment}
```

is supported by a package