### PR TITLE
Use Github token by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create a `workflow.yml` file in your `.github/workflows` directory like:
             uses: "alstr/todo-to-issue-action@v4.0.7"
             id: "todo"
             with:
-              TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              TOKEN: ${{ secrets.GITHUB_TOKEN }} // defaults to ${{ github.token }}
 ```
 
 See [Github's workflow syntax](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions) for further details on this file.
@@ -49,7 +49,7 @@ The workflow file takes the following inputs:
 
 | Input    | Required | Description |
 |----------|----------|-------------|
-| `TOKEN` | Yes | The GitHub access token to allow us to retrieve, create and update issues for your repo. This should be set to `${{ secrets.GITHUB_TOKEN }}`. |
+| `TOKEN` | No | The GitHub access token to allow us to retrieve, create and update issues for your repo. Default: `${{ github.token }}` |
 | `CLOSE_ISSUES` | No | Optional boolean input that specifies whether to attempt to close an issue when a TODO is removed. Default: `true`. |
 | `AUTO_P` | No | Optional boolean input that specifies whether to format each line in multiline TODOs as a new paragraph. Default: `true`. |
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,8 @@ inputs:
     default: "${{ github.sha }}"
   TOKEN:
     description: "The GitHub access token to allow us to retrieve, create and update issues (automatically set)"
-    required: true
+    required: false
+    default: "${{ github.token }}"
   LABEL:
     description: "The label that will be used to identify TODO comments (deprecated)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   TOKEN:
     description: "The GitHub access token to allow us to retrieve, create and update issues (automatically set)"
     required: false
-    default: "${{ github.token }}"
+    default: ${{ github.token }}
   LABEL:
     description: "The label that will be used to identify TODO comments (deprecated)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   TOKEN:
     description: "The GitHub access token to allow us to retrieve, create and update issues (automatically set)"
     required: false
-    default: ${{ github.token }}
+    default: "${{ github.token }}"
   LABEL:
     description: "The label that will be used to identify TODO comments (deprecated)"
     required: false

--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ class GitHubClient(object):
         self.repo = os.getenv('INPUT_REPO')
         self.before = os.getenv('INPUT_BEFORE')
         self.sha = os.getenv('INPUT_SHA')
-        self.token = os.getenv('INPUT_TOKEN') or core.get_input('TOKEN')
+        self.token = core.get_input('TOKEN')
         self.issues_url = f'{self.repos_url}{self.repo}/issues'
         self.issue_headers = {
             'Content-Type': 'application/json',

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from io import StringIO
 from ruamel.yaml import YAML
 import hashlib
 from enum import Enum
-
+from actions_toolkit import core
 
 class LineStatus(Enum):
     """Represents the status of a line in a diff file."""
@@ -48,7 +48,7 @@ class GitHubClient(object):
         self.repo = os.getenv('INPUT_REPO')
         self.before = os.getenv('INPUT_BEFORE')
         self.sha = os.getenv('INPUT_SHA')
-        self.token = os.getenv('INPUT_TOKEN')
+        self.token = os.getenv('INPUT_TOKEN') or core.get_input('TOKEN')
         self.issues_url = f'{self.repos_url}{self.repo}/issues'
         self.issue_headers = {
             'Content-Type': 'application/json',


### PR DESCRIPTION
To simplify the action, we can add the Github token in the default field for the `TOKEN` input. This would make the action a bit less verbose for normal use. Now the action will default to Github token by default without needing an explicit definition.

Edit: I don't know how to test this but it'd be good if you can test whether or not it works as expected.