### PR TITLE
Add support for ABAP and ABAP CDS languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ There are additional inputs if you want to be able to assign issues to projects.
 
 ## Supported Languages
 
+* ABAP
+* ABAP CDS
 * AutoHotkey
 * C
 * C++

--- a/syntax.json
+++ b/syntax.json
@@ -494,7 +494,7 @@
       },
       {
         "type": "line",
-        "pattern": "\*"
+        "pattern": "\\*"
       }
     ]
   },

--- a/syntax.json
+++ b/syntax.json
@@ -484,5 +484,34 @@
         "pattern": "//"
       }
     ]
+  },
+  {
+    "language": "ABAP",
+    "markers": [
+      {
+        "type": "line",
+        "pattern": "\""
+      },
+      {
+        "type": "line",
+        "pattern": "*"
+      }
+    ]
+  },
+  {
+    "language": "ABAP CDS",
+    "markers": [
+      {
+        "type": "line",
+        "pattern": "//"
+      },
+      {
+        "type": "block",
+        "pattern": {
+          "start": "/\\*",
+          "end": "\\*/"
+        }
+      }
+    ]
   }
 ]

--- a/syntax.json
+++ b/syntax.json
@@ -494,7 +494,7 @@
       },
       {
         "type": "line",
-        "pattern": "*"
+        "pattern": "\*"
       }
     ]
   },


### PR DESCRIPTION
Reference to the documentation of comment syntax:

ABAP
https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/index.htm?file=abencomment.htm

ABAP CDS
https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/index.htm?file=abencds_general_syntax_rules.htm

Closes #85