### PR TITLE
Fix LaTeX bug + add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,142 @@
+### https://raw.github.com/github/gitignore/218a941be92679ce67d0484547e3e142b2f5f6f0/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ There are additional inputs if you want to be able to assign issues to projects.
 * Vue
 * YAML
 
-New languages can easily be added to the `syntax.json` file used by the action to identify TODO comments. When adding languages, follow the structure of existing entries, and use the language name defined by GitHub in [`languages.yml`](https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml). PRs adding new languages are welcome and appreciated.
+New languages can easily be added to the `syntax.json` file used by the action to identify TODO comments. When adding languages, follow the structure of existing entries, and use the language name defined by GitHub in [`languages.yml`](https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml). PRs adding new languages are welcome and appreciated. Please add a test for your language in order for your PR to be accepted. 
 
 ## TODO Options
 
@@ -172,6 +172,14 @@ Issues are created whenever the action runs and finds a newly added TODO in the 
 ## Contributing & Issues
 
 If you do encounter any problems, please file an issue or submit a PR. Everyone is welcome and encouraged to contribute.
+
+
+## Running tests locally 
+
+To run the tests locally, simply run the following in the main repo:
+```shell
+python -m unittest
+```
 
 ## Thanks
 

--- a/syntax.json
+++ b/syntax.json
@@ -408,8 +408,8 @@
       {
         "type": "block",
         "pattern": {
-          "start": "\\begin{comment}",
-          "end": "\\end{comment}"
+          "start": "\\\\begin{comment}",
+          "end": "\\\\end{comment}"
         }
       }
     ]

--- a/tests/test_closed.diff
+++ b/tests/test_closed.diff
@@ -107,3 +107,64 @@ index 6397789..494d42f 100644
 @@ -1,2 +0,0 @@
 --- TODO Select all:
 -SELECT * FROM Products;
+diff --git a/tests/example_file.tex b/src/tests/example_file.tex
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.tex
+@@ -0,0 +1,2 @@
+-% TODO Add in preamble details
+-\begin{document}
+-  \begin{comment}
+-     TODO This document needs content
+-     label: urgent
+-  \end{comment}
+-\end{document}
+diff --git a/tests/example_file.jl b/src/tests/example_file.jl
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.jl
+@@ -0,0 +1,2 @@
+- # TODO: Hopefully this comment turns into an issue
+- print("Hello World")
+- #= TODO: Multiline comments
+-   also need to be turned into task, and hopefully 
+-   kept together as one.
+- =#
+diff --git a/tests/example_file.ahk b/src/tests/example_file.ahk
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.ahk
+@@ -0,0 +1,2 @@
+- ; TODO: Find a better way to manage hotkeys
+- ; Maybe just switch to vim??
+- #h::
+- RegRead, HiddenFiles_Status, HKEY_CURRENT_USER, Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced, Hidden 
+diff --git a/tests/example_file.hbs b/src/tests/example_file.hbs
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.hbs
+@@ -0,0 +1,2 @@
+- <!-- TODO: Hopefully this comment turns into a todo issue -->
+- {{! 
+-   TODO: Make a handlebar templtate
+-    This is really just a test, but hopefully this works~!
+- }}
+diff --git a/tests/example_file.org b/src/tests/example_file.org
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.org
+@@ -0,0 +1,2 @@
+- # TODO: Hopefully this comment turns into a todo issue
+- #+begin_src python
+- print("Hello World")
+- #+end_src
+- + #+begin_comment
+-  TODO: Multiline comments
+-   also need to be turned into todos, and hopefully 
+-   kept together as one todo
+- #+end_comment

--- a/tests/test_new.diff
+++ b/tests/test_new.diff
@@ -113,3 +113,66 @@ index 0000000..7cccc5b
 @@ -0,0 +1,2 @@
 +-- TODO Select all:
 +SELECT * FROM Products;
+diff --git a/tests/example_file.tex b/src/tests/example_file.tex
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.tex
+@@ -0,0 +1,2 @@
++% TODO Add in preamble details
++\begin{document}
++  \begin{comment}
++     TODO This document needs content
++     label: urgent
++  \end{comment}
++\end{document}
+diff --git a/tests/example_file.jl b/src/tests/example_file.jl
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.jl
+@@ -0,0 +1,2 @@
++ # TODO: Hopefully this comment turns into an issue
++ print("Hello World")
++ #= TODO: Multiline comments
++   also need to be turned into task, and hopefully 
++   kept together as one.
++ =#
+diff --git a/tests/example_file.ahk b/src/tests/example_file.ahk
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.ahk
+@@ -0,0 +1,2 @@
++ ; TODO: Find a better way to manage hotkeys
++ ; Maybe just switch to vim??
++ #h::
++ RegRead, HiddenFiles_Status, HKEY_CURRENT_USER, Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced, Hidden 
+diff --git a/tests/example_file.hbs b/src/tests/example_file.hbs
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.hbs
+@@ -0,0 +1,2 @@
++ <!-- TODO: Hopefully this comment turns into a todo issue -->
++ {{! 
++   TODO: Make a handlebar templtate
++    This is really just a test, but hopefully this works~!
++ }}
+diff --git a/tests/example_file.org b/src/tests/example_file.org
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/src/tests/example_file.org
+@@ -0,0 +1,2 @@
++ # TODO: Hopefully this comment turns into a todo issue
++ #+begin_src python
++ print("Hello World")
++ #+end_src
++ #+begin_comment
++  TODO: Multiline comments
++   also need to be turned into todos, and hopefully 
++   kept together as one todo
++ #+end_comment
+
+

--- a/tests/test_todo_parser.py
+++ b/tests/test_todo_parser.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import json
 from main import TodoParser
 
 
@@ -15,7 +16,10 @@ class NewIssueTests(unittest.TestCase):
     # Check for newly added TODOs across the files specified.
     def setUp(self):
         diff_file = open('tests/test_new.diff', 'r')
-        self.raw_issues = TodoParser().parse(diff_file)
+        parser = TodoParser()
+        with open('syntax.json', 'r') as syntax_json: 
+            parser.syntax_dict = json.load(syntax_json)
+        self.raw_issues = parser.parse(diff_file)
 
     def test_python_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 2)
@@ -38,15 +42,29 @@ class NewIssueTests(unittest.TestCase):
     def test_sql_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'sql'), 1)
 
-    # TODO: Update tests
-    #  Need tests for Julia, AutoHotKey, Handlebars, Org and TeX, as these markers are not currently covered.
+    def test_tex_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'tex'), 2)
 
+    def test_julia_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'julia'), 2)
+
+    def test_autohotkey_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'autohotkey'), 1)
+    
+    def test_handlebars_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'handlebars'), 2)
+    
+    def test_org_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'text'), 2)
 
 class ClosedIssueTests(unittest.TestCase):
     # Check for removed TODOs across the files specified.
     def setUp(self):
         diff_file = open('tests/test_closed.diff', 'r')
-        self.raw_issues = TodoParser().parse(diff_file)
+        parser = TodoParser()
+        with open('syntax.json', 'r') as syntax_json: 
+            parser.syntax_dict = json.load(syntax_json)
+        self.raw_issues = parser.parse(diff_file)
 
     def test_python_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 2)
@@ -68,14 +86,32 @@ class ClosedIssueTests(unittest.TestCase):
 
     def test_sql_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'sql'), 1)
+
+    def test_tex_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'tex'), 2)
+    
+    def test_julia_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'julia'), 2)
+
+    def test_autohotkey_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'autohotkey'), 1)
+    
+    def test_handlebars_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'handlebars'), 2)
+    
+    def test_org_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'text'), 2)
 
 
 class IgnorePatternTests(unittest.TestCase):
 
     def test_single_ignore(self):
         os.environ['INPUT_IGNORE'] = '.*\\.java'
-        diff_file = open('tests/test_new.diff', 'r')
-        self.raw_issues = TodoParser().parse(diff_file)
+        parser = TodoParser()
+        with open('syntax.json', 'r') as syntax_json: 
+            parser.syntax_dict = json.load(syntax_json)
+        diff_file = open('tests/test_closed.diff', 'r')
+        self.raw_issues = parser.parse(diff_file)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 2)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'yaml'), 2)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'php'), 4)
@@ -85,8 +121,11 @@ class IgnorePatternTests(unittest.TestCase):
 
     def test_multiple_ignores(self):
         os.environ['INPUT_IGNORE'] = '.*\\.java, tests/example-file\\.php'
-        diff_file = open('tests/test_new.diff', 'r')
-        self.raw_issues = TodoParser().parse(diff_file)
+        parser = TodoParser()
+        with open('syntax.json', 'r') as syntax_json: 
+            parser.syntax_dict = json.load(syntax_json)
+        diff_file = open('tests/test_closed.diff', 'r')
+        self.raw_issues = parser.parse(diff_file)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 2)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'yaml'), 2)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'php'), 0)


### PR DESCRIPTION
This PR aims to 
- Fix the issues observed in: https://github.com/alstr/todo-to-issue-action/issues/95
- Add test coverage for LaTeX line + block comments

I was able to identify this by adding a local change to swap `\begin` => `\\begin` and `\end` => `\\end` in the regex parts for LaTeX before parsing. However, not all tests pass after doing this (which appears to be due to other underlying issues with the tests). 

Also worth noting that the tests right now depend explicitly on the version of `syntax.json` which is on master of this repo, which makes it painful to test locally. I overrode that in the tests file to make them easier to work with in the future