### PR TITLE
feat: add Crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ There are additional inputs if you want to be able to assign issues to projects.
 * C++
 * C#
 * CSS
+* Crystal
 * Dart
 * Elixir
 * Go

--- a/syntax.json
+++ b/syntax.json
@@ -591,5 +591,14 @@
         }
       }
     ]
+  },
+  {
+    "language": "Crystal",
+    "markers": [
+      {
+        "type": "line",
+        "pattern": "#"
+      }
+    ]
   }
 ]

--- a/tests/test_closed.diff
+++ b/tests/test_closed.diff
@@ -75,6 +75,17 @@ index 525e25d..ba4e68d 100644
 -    kept together as one.
 -    '''
 -    pass
+diff --git a/tests/example_file.cr b/tests/example_file.cr
+index e6da2ec..67f14dd 100644
+--- a/tests/example_file.cr
++++ b/tests/example_file.cr
+@@ -1,14 +1,3 @@
+-# TODO: Come up with a more imaginative greeting
+ puts "Greetings"
+-
+-# TODO: Do even more stuff
+-# This function should probably do something more interesting
+-# labels: help wanted
 diff --git a/tests/example_file.rb b/tests/example_file.rb
 index e6da2ec..67f14dd 100644
 --- a/tests/example_file.rb

--- a/tests/test_new.diff
+++ b/tests/test_new.diff
@@ -78,6 +78,18 @@ index 0000000..525e25d
 +    '''
 +    pass
 \ No newline at end of file
+diff --git a/tests/example_file.cr b/tests/example_file.cr
+new file mode 100644
+index 0000000..e6da2ec
+--- /dev/null
++++ b/tests/example_file.cr
+@@ -0,0 +1,14 @@
++# TODO: Come up with a more imaginative greeting
++puts "Greetings"
++
++# TODO: Do even more stuff
++# This function should probably do something more interesting
++# labels: help wanted
 diff --git a/tests/example_file.rb b/tests/example_file.rb
 new file mode 100644
 index 0000000..e6da2ec

--- a/tests/test_todo_parser.py
+++ b/tests/test_todo_parser.py
@@ -33,6 +33,9 @@ class NewIssueTests(unittest.TestCase):
     def test_java_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'java'), 2)
 
+    def test_crystal_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'crystal'), 2)
+
     def test_ruby_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'ruby'), 3)
 
@@ -50,10 +53,10 @@ class NewIssueTests(unittest.TestCase):
 
     def test_autohotkey_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'autohotkey'), 1)
-    
+
     def test_handlebars_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'handlebars'), 2)
-    
+
     def test_org_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'text'), 2)
 
@@ -85,6 +88,9 @@ class ClosedIssueTests(unittest.TestCase):
     def test_java_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'java'), 2)
 
+    def test_crystal_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'crystal'), 2)
+
     def test_ruby_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'ruby'), 3)
 
@@ -96,16 +102,16 @@ class ClosedIssueTests(unittest.TestCase):
 
     def test_tex_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'tex'), 2)
-    
+
     def test_julia_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'julia'), 2)
 
     def test_autohotkey_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'autohotkey'), 1)
-    
+
     def test_handlebars_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'handlebars'), 2)
-    
+
     def test_org_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'text'), 2)
 

--- a/tests/test_todo_parser.py
+++ b/tests/test_todo_parser.py
@@ -37,7 +37,8 @@ class NewIssueTests(unittest.TestCase):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'crystal'), 2)
 
     def test_ruby_issues(self):
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'ruby'), 3)
+        # Includes 2 tests for Crystal.
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'ruby'), 5)
 
     def test_abap_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'abap'), 2)
@@ -88,11 +89,9 @@ class ClosedIssueTests(unittest.TestCase):
     def test_java_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'java'), 2)
 
-    def test_crystal_issues(self):
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'crystal'), 2)
-
     def test_ruby_issues(self):
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'ruby'), 3)
+        # Includes 2 tests for Crystal.
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'ruby'), 5)
 
     def test_abap_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'abap'), 2)


### PR DESCRIPTION
Adds support for [Crystal](https://crystal-lang.org/), a statically compiled language that is _very_ similar in syntax to Ruby.