### PR TITLE
Add support of javadoc syntax

### DIFF
--- a/syntax.json
+++ b/syntax.json
@@ -143,6 +143,12 @@
         "pattern": {
           "start": "/\\*",
           "end": "\\*/"
+        },
+      {
+        "type": "block",
+        "pattern": {
+          "start": "/\\*\\*",
+          "end": "\\*/"
         }
       }
     ]


### PR DESCRIPTION
Javadoc comment format for java language has the following format
````java
/**
 * This is the user.
 * @author someone
 * @since 0.0.0
 */
public class User {
   
}
```