### PR TITLE
Adding `\todo` for LaTeX todos

### DIFF
--- a/syntax.json
+++ b/syntax.json
@@ -431,6 +431,10 @@
         "pattern": "%"
       },
       {
+        "type": "line",
+        "pattern": "\\\\todo{"
+      },
+      {
         "type": "block",
         "pattern": {
           "start": "\\\\begin{comment}",


### PR DESCRIPTION
Many packages (e.g. `todo`, `easy-todo`, `todonotes`) in LaTeX visually track TODOs in a document which makes them easy to see when editing; especially when sending to external editors. This commit adds support for these packages in LaTeX and creates GitHub issues just like you would have from a regular inline comment.