### PR TITLE
Add GITHUB_URL to support GHES

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,3 +72,7 @@ inputs:
   IDENTIFIERS:
     description: 'Dictionary of custom identifiers'
     required: false
+  GITHUB_URL:
+    description: 'Base url of GitHub API'
+    required: false
+    default: ${{ github.api_url }}

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ class GitHubClient(object):
 
     def __init__(self):
         self.github_url = os.getenv('INPUT_GITHUB_URL')
-        self.base_url = f'{self.base_url}/'
+        self.base_url = f'{self.github_url}/'
         self.repos_url = f'{self.base_url}repos/'
         self.repo = os.getenv('INPUT_REPO')
         self.before = os.getenv('INPUT_BEFORE')

--- a/main.py
+++ b/main.py
@@ -43,10 +43,11 @@ class Issue(object):
 class GitHubClient(object):
     """Basic client for getting the last diff and creating/closing issues."""
     existing_issues = []
-    base_url = 'https://api.github.com/'
-    repos_url = f'{base_url}repos/'
 
     def __init__(self):
+        self.github_url = os.getenv('INPUT_GITHUB_URL')
+        self.base_url = f'{self.base_url}/'
+        self.repos_url = f'{self.base_url}repos/'
         self.repo = os.getenv('INPUT_REPO')
         self.before = os.getenv('INPUT_BEFORE')
         self.sha = os.getenv('INPUT_SHA')


### PR DESCRIPTION
GitHub Enterprise Server uses a different API endpoint. This PR is aimed to support running this action on GHES by adding a new optional action input.