### PR TITLE
Add support for Starlark.

### DIFF
--- a/syntax.json
+++ b/syntax.json
@@ -189,6 +189,15 @@
     ]
   },
   {
+    "language": "Starlark",
+    "markers": [
+      {
+        "type": "line",
+        "pattern": "#"
+      }
+    ]
+  },
+  {
     "language": "TypeScript",
     "markers": [
       {

--- a/tests/test_closed.diff
+++ b/tests/test_closed.diff
@@ -159,6 +159,12 @@ index 0000000..7cccc5b
 -   also need to be turned into task, and hopefully
 -   kept together as one.
 - =#
+diff --git a/tests/defs.bzl b/tests/defs.bzl
+index 525e25d..ba4e68d 100644
+--- a/tests/defs.bzl
++++ b/tests/defs.bzl
+@@ -0,0 +0,1 @@
+-    # TODO: Come up with a more imaginative greeting
 diff --git a/tests/example_file.ahk b/src/tests/example_file.ahk
 new file mode 100644
 index 0000000..7cccc5b

--- a/tests/test_new.diff
+++ b/tests/test_new.diff
@@ -187,6 +187,20 @@ index 0000000..7cccc5b
 +   also need to be turned into task, and hopefully
 +   kept together as one.
 + =#
+diff --git a/tests/defs.bzl b/tests/defs.bzl
+new file mode 100644
+index 0000000..525e25d
+--- /dev/null
++++ b/tests/defs.bzl
+@@ -0,0 +1,23 @@
++def hello_world():
++    # TODO: Come up with a more imaginative greeting
++    print('Hello world')
++
++    # TODO: Do more stuff
++    #  This function should probably do something more interesting
++    #  labels: help wanted
++    pass
 diff --git a/tests/example_file.ahk b/src/tests/example_file.ahk
 new file mode 100644
 index 0000000..7cccc5b

--- a/tests/test_todo_parser.py
+++ b/tests/test_todo_parser.py
@@ -23,7 +23,8 @@ class NewIssueTests(unittest.TestCase):
         self.raw_issues = parser.parse(diff_file)
 
     def test_python_issues(self):
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 4)
+        # Includes 2 tests for Starlark.
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 6)
 
     def test_yaml_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'yaml'), 2)
@@ -52,6 +53,9 @@ class NewIssueTests(unittest.TestCase):
 
     def test_julia_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'julia'), 2)
+
+    def test_starlark_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 6)
 
     def test_autohotkey_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'autohotkey'), 1)
@@ -96,7 +100,8 @@ class ClosedIssueTests(unittest.TestCase):
         self.raw_issues = parser.parse(diff_file)
 
     def test_python_issues(self):
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 4)
+        # Includes 1 test for Starlark.
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 5)
 
     def test_yaml_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'yaml'), 2)
@@ -122,6 +127,9 @@ class ClosedIssueTests(unittest.TestCase):
 
     def test_julia_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'julia'), 2)
+
+    def test_starlark_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 5)
 
     def test_json5_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'javascript'), 1)
@@ -168,7 +176,7 @@ class IgnorePatternTests(unittest.TestCase):
             parser.syntax_dict = json.load(syntax_json)
         diff_file = open('tests/test_closed.diff', 'r')
         self.raw_issues = parser.parse(diff_file)
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 4)
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 5)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'yaml'), 2)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'php'), 4)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'java'), 0)
@@ -183,7 +191,7 @@ class IgnorePatternTests(unittest.TestCase):
             parser.syntax_dict = json.load(syntax_json)
         diff_file = open('tests/test_closed.diff', 'r')
         self.raw_issues = parser.parse(diff_file)
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 4)
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 5)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'yaml'), 2)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'php'), 0)
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'java'), 0)


### PR DESCRIPTION
Support is similar to Python, as it is a python dialect.  However, it does not support block comments.

See spec: https://github.com/bazelbuild/starlark/blob/master/spec.md