### PR TITLE
Allows to have no spaces between a comment pattern and a TODO identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,5 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-
+# JetBrains
+.idea

--- a/main.py
+++ b/main.py
@@ -439,8 +439,6 @@ class TodoParser(object):
                                        marker['pattern'] +
                                        (r'(?!(' + '|'.join(suff_escape_list) + r'))' if len(suff_escape_list) > 0 else '') +
                                        r'\s*.+$)')
-                    if block['markdown_language'] == "ruby":
-                        print(comment_pattern)
                     comments = re.finditer(comment_pattern, block['hunk'], re.MULTILINE)
                     extracted_comments = []
                     prev_comment = None

--- a/tests/test_closed.diff
+++ b/tests/test_closed.diff
@@ -153,9 +153,14 @@ index 0000000..7cccc5b
 --- /dev/null
 +++ b/src/tests/example_file.jl
 @@ -0,0 +1,2 @@
-- # TODO: Hopefully this comment turns into an issue
+- #TODO: Hopefully this comment turns into an issue
+- # TODO: Hopefully this comment also turns into an issue
 - print("Hello World")
 - #= TODO: Multiline comments
+-   also need to be turned into task, and hopefully
+-   kept together as one.
+- =#
+- #=TODO: Another copied multiline comment
 -   also need to be turned into task, and hopefully
 -   kept together as one.
 - =#

--- a/tests/test_todo_parser.py
+++ b/tests/test_todo_parser.py
@@ -129,7 +129,7 @@ class ClosedIssueTests(unittest.TestCase):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'tex'), 2)
 
     def test_julia_issues(self):
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'julia'), 2)
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'julia'), 4)
 
     def test_starlark_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'python'), 5)


### PR DESCRIPTION
As mentioned in the title, you no longer need to include a space between a comment pattern and an identifier (See #155).

Additionally, I would like to mention that I have only updated some unit tests for the Julia programming language. If this is not sufficient, please leave a comment, and I will add more as needed.