### PR TITLE
add support for Liquid files (.liquid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ These will be applied automatically to every issue, but will be overrode by any 
 - Julia
 - Kotlin
 - Less
+- Liquid
 - Makefile
 - Markdown
 - Nix

--- a/syntax.json
+++ b/syntax.json
@@ -773,5 +773,21 @@
         "pattern": "#"
       }
     ]
+  },
+  {
+    "language": "Liquid",
+    "markers": [
+      {
+        "type": "line",
+        "pattern": "#"
+      },
+      {
+        "type": "block",
+        "pattern": {
+          "start": "{% comment %}",
+          "end": "{% endcomment %}"
+        }
+      }
+    ]
   }
 ]

--- a/tests/test_closed.diff
+++ b/tests/test_closed.diff
@@ -392,3 +392,19 @@ index 2996176..7545ccf 100644
 -	# TODO create the directory.
  	$(AR) rc $@ $(OBJ)
  
+diff --git a/tests/example_file.liquid b/tests/example_file.liquid
+index 0000000..7cccc5b 100644
+--- a/tests/example_file.liquid
++++ b/tests/example_file.liquid
+@@ -1,6 +0,0 @@
+-{% comment %} TODO: remove loop logic {% endcomment %}
+ {% for i in (1..3) -%}
+- # TODO: Do math here!
+- # labels: help wanted
+   {{ i }}
+ {% endfor %}
+-{% comment %}
+-TODO: Render Liquid file
+ {% assign featured_product = all_products["product_handle"] %}
+ {% render "product", product: featured_product %}
+-{% endcomment %}

--- a/tests/test_new.diff
+++ b/tests/test_new.diff
@@ -435,3 +435,20 @@ index 0000000..2996176
 +	# TODO create the directory.
 +	$(AR) rc $@ $(OBJ)
 +
+diff --git a/tests/example_file.liquid b/tests/example_file.liquid
+new file mode 100644
+index 0000000..7cccc5b
+--- /dev/null
++++ b/tests/example_file.liquid
+@@ -0,0 +1,11 @@
++{% comment %} TODO: remove loop logic {% endcomment %}
++{% for i in (1..3) -%}
++ # TODO: Do math here!
++ # labels: help wanted
++  {{ i }}
++{% endfor %}
++{% comment %}
++TODO: Render Liquid file
++{% assign featured_product = all_products["product_handle"] %}
++{% render "product", product: featured_product %}
++{% endcomment %}

--- a/tests/test_todo_parser.py
+++ b/tests/test_todo_parser.py
@@ -190,7 +190,7 @@ class ClosedIssueTests(unittest.TestCase):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'c_cpp'), 2)
 
     def test_liquid_issues(self):
-        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'liquid'), 3);
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'liquid'), 3)
 
 
 class IgnorePatternTests(unittest.TestCase):

--- a/tests/test_todo_parser.py
+++ b/tests/test_todo_parser.py
@@ -99,6 +99,9 @@ class NewIssueTests(unittest.TestCase):
     def test_c_cpp_like_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'c_cpp'), 2)
 
+    def test_liquid_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'liquid'), 3)
+
 
 class ClosedIssueTests(unittest.TestCase):
     # Check for removed TODOs across the files specified.
@@ -185,6 +188,9 @@ class ClosedIssueTests(unittest.TestCase):
     
     def test_c_cpp_like_issues(self):
         self.assertEqual(count_issues_for_file_type(self.raw_issues, 'c_cpp'), 2)
+
+    def test_liquid_issues(self):
+        self.assertEqual(count_issues_for_file_type(self.raw_issues, 'liquid'), 3);
 
 
 class IgnorePatternTests(unittest.TestCase):


### PR DESCRIPTION
Although line comments in Liquid require a wrapping liquid block in one way or another, I've included the line syntax `#` without consideration for the `{% %}` encapsulation due to the unlikelihood that `# TODO` will be used outside of a comment context.

Liquid input:
```liquid
{% # for i in (1..3) -%}
  {{ i }}
{% # endfor %}
# Not a comment
{%
  ###############################
  # This is a comment
  # across multiple lines
  ###############################
%}
```
Output:
```
# Not a comment
```

I'd be happy to make any changes that are suggested.