### PR TITLE
Fix link generation for GitHub Enterprise by using `GITHUB_SERVER_URL`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: 'Base url of GitHub API'
     required: false
     default: ${{ github.api_url }}
+  GITHUB_SERVER_URL:
+    description: 'Base URL of GitHub web interface'
+    required: false
+    default: ${{ github.server_url }}
   ESCAPE:
     description: 'Escape all special Markdown characters'
     required: false

--- a/main.py
+++ b/main.py
@@ -75,10 +75,9 @@ class GitHubClient(object):
         self.auto_assign = os.getenv('INPUT_AUTO_ASSIGN', 'false') == 'true'
         self.actor = os.getenv('INPUT_ACTOR')
         self.insert_issue_urls = os.getenv('INPUT_INSERT_ISSUE_URLS', 'false') == 'true'
-        if self.base_url == 'https://api.github.com/':
-            self.line_base_url = 'https://github.com/'
-        else:
-            self.line_base_url = self.base_url
+        self.line_base_url = os.getenv('INPUT_GITHUB_SERVER_URL')
+        if not self.line_base_url.endswith('/'):
+            self.line_base_url += '/'
         self.project = os.getenv('INPUT_PROJECT', None)
         # Retrieve the existing repo issues now so we can easily check them later.
         self._get_existing_issues()


### PR DESCRIPTION
## Summary
This pull request fixes an issue where the todo-to-issue GitHub Action does not correctly generate links in GitHub Enterprise (GHE) environments due to incorrect base URLs. The action was previously using the API URL (GITHUB_URL) for generating web links, which is not appropriate for GHE, as the API URL and web interface URL differ.

## Reason for Changes

### Issue in GHE Environments
  - The action was using the API base URL (GITHUB_URL) to generate links, which is incorrect for GHE.
  - In GHE, the API URL (e.g., https://github.company.com/api/v3) is different from the web interface URL (e.g., https://github.company.com/).

### Solution
By introducing GITHUB_SERVER_URL as an input, we can obtain the correct web interface URL.
This ensures that issue links, code permalinks, and code snippets point to the correct location.

## Impact

### For GitHub Enterprise Users
- Correctly generates links in issues.
- Improves compatibility and usability of the action in GHE environments.

### For GitHub.com Users
- No impact on existing functionality.
- The action continues to work as before, using the default github.server_url.

## Documentation Updates
The README has not been updated at the time this Pull Request was created. This is because I think the content of this PR is controversial. (regarding naming of GITHUB_SEREVR_URL, etc.)
So if the content of the implementation is OK, I will add the content to the README.

---

Thank you for considering this pull request. Please let me know if you have any questions or need further adjustments.