### PR TITLE
fix: get correct line numbering of old and new lines

### DIFF
--- a/tests/test_process_diff.py
+++ b/tests/test_process_diff.py
@@ -80,8 +80,6 @@ class IssueUrlInsertionTest(unittest.TestCase):
         self._setUp(['test_new.diff'])
         self._standardTest(80)
 
-    # See GitHub issue #236
-    @unittest.expectedFailure
     def test_line_numbering_with_deletions(self):
         self._setUp(['test_new_py.diff', 'test_edit_py.diff'])
         with self.subTest("Issue URL insertion"):


### PR DESCRIPTION
track context of old and new lines separately to
get proper line numbers relative to old and
new version of a file

Closes GitHub #236