### PR TITLE
fix: don't include source with issue URL comment

### DIFF
--- a/Issue.py
+++ b/Issue.py
@@ -2,7 +2,7 @@ class Issue(object):
     """Basic Issue model for collecting the necessary info to send to GitHub."""
 
     def __init__(self, title, labels, assignees, milestone, body, hunk, file_name,
-                 start_line, num_lines, markdown_language, status, identifier, identifier_actual, ref, issue_url, issue_number, start_line_within_hunk=1):
+                 start_line, num_lines, prefix, markdown_language, status, identifier, identifier_actual, ref, issue_url, issue_number, start_line_within_hunk=1):
         self.title = title
         self.labels = labels
         self.assignees = assignees
@@ -12,6 +12,7 @@ class Issue(object):
         self.file_name = file_name
         self.start_line = start_line
         self.num_lines = num_lines
+        self.prefix = prefix
         self.markdown_language = markdown_language
         self.status = status
         self.identifier = identifier

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ def process_diff(diff, client=Client(), insert_issue_urls=False, parser=TodoPars
                         old_line = file_lines[line_number]
                         remove = fr'(?i:{raw_issue.identifier}).*{re.escape(raw_issue.title)}'
                         insert = f'Issue URL: {client.get_issue_url(new_issue_number)}'
-                        new_line = re.sub(remove, insert, old_line)
+                        new_line = re.sub('^.*'+remove, raw_issue.prefix + insert, old_line)
                         # make sure the above operation worked as intended
                         if new_line != old_line:
                             # Check if the URL line already exists, if so abort.

--- a/tests/test_process_diff.py
+++ b/tests/test_process_diff.py
@@ -110,10 +110,6 @@ class IssueUrlInsertionTest(unittest.TestCase):
         self._setUp(['test_same_title_in_same_file.diff'])
         self._standardTest(5)
 
-    # There is a known bug related to this issue, so until it's resolved
-    # this is an expected failure.
-    # See #229
-    @unittest.expectedFailure
     def test_comment_suffix_after_source_line(self):
         self._setUp(['test_comment_suffix_after_source_line.diff'])
         self._standardTest(1)


### PR DESCRIPTION
If TODO comment is a suffix to a line of
(executable) source, don't repeat the source
content when inserting the issue URL. But be sure
to still keep the same alignment.

Closes #229