### PR TITLE
feat: adding default labels to issues

### DIFF
--- a/GitHubClient.py
+++ b/GitHubClient.py
@@ -268,6 +268,7 @@ class GitHubClient(Client):
         snippet = '```' + issue.markdown_language + '\n' + issue.hunk + '\n' + '```'
 
         issue_template = os.getenv('INPUT_ISSUE_TEMPLATE', None)
+        default_labels = os.getenv('INPUT_DEFAULT_LABELS', None)
         if issue_template:
             issue_contents = (issue_template.replace('{{ title }}', issue.title)
                               .replace('{{ body }}', formatted_issue_body)
@@ -285,6 +286,14 @@ class GitHubClient(Client):
             endpoint += f'/{issue.issue_number}'
 
         title = issue.title
+
+        if default_labels:
+            # Ensure default_labels is treated as a list (in case it's a string from the environment variable)
+            if isinstance(default_labels, str):
+                default_labels = [label.strip() for label in default_labels.split(',') if label.strip()]
+
+            # Combine default labels with any existing labels, avoiding duplicates
+            issue.labels = list(set(issue.labels + default_labels))
 
         if issue.ref:
             if issue.ref.startswith('@'):

--- a/README.md
+++ b/README.md
@@ -400,6 +400,10 @@ placeholders:
 
 If not specified the standard template is used, containing the issue body (if a multiline TODO), URL and snippet.
 
+##### DEFAULT_LABELS
+
+Custom labels that can be automatically appended to newly created issues, in a form of comma-delimited strings.
+
 #### LANGUAGES
 
 A collection of comma-delimited URLs or local paths (starting from the current working directory of the action)

--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ for improved accuracy.
 
 Default: `False`
 
+##### DEFAULT_LABELS
+
+Custom labels that can be automatically appended to newly created issues, in a form of comma-delimited strings.
+
 #### ESCAPE
 
 Escape all special Markdown characters.
@@ -399,10 +403,6 @@ placeholders:
 * `{{ snippet }}`: code snippet of the relevant section
 
 If not specified the standard template is used, containing the issue body (if a multiline TODO), URL and snippet.
-
-##### DEFAULT_LABELS
-
-Custom labels that can be automatically appended to newly created issues, in a form of comma-delimited strings.
 
 #### LANGUAGES
 

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,9 @@ inputs:
   ISSUE_TEMPLATE:
     description: 'The template used to format new issues'
     required: false
+  DEFAULT_LABELS:
+    description: 'Default labels to be used when add new issues'
+    required: false
   IDENTIFIERS:
     description: 'Dictionary of custom identifiers'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ inputs:
     description: 'The template used to format new issues'
     required: false
   DEFAULT_LABELS:
-    description: 'Default labels to be used when add new issues'
+    description: 'Default labels to be used when adding new issues'
     required: false
   IDENTIFIERS:
     description: 'Dictionary of custom identifiers'


### PR DESCRIPTION
I made it so that you can supply a csv string of default labels to the action, which will be used to automatically apply labels to newly created issues, in addition to the individually tagged labels via the `labels:` comment.

I wasn't sure how to go about testing this, but I basically copied the implementation for Issue_template but configured it for the issue labels.