### PR TITLE
fix: remove subdirectory paths from test_new.diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
       - name: "Run tests"
         run: python -m unittest discover
         env:
-          SKIP_PROCESS_DIFF_TEST: true
+          SKIP_PROCESS_DIFF_TEST: false

--- a/tests/test_new.diff
+++ b/tests/test_new.diff
@@ -563,7 +563,7 @@ index 0000000..d340f6a
 +    * labels: urgent
 +    */
 +}
-diff --git a/tests/package.move b/tests/package.move
+diff --git a/package.move b/package.move
 new file mode 100644
 index 0000000..d340f6a
 --- /dev/null
@@ -589,11 +589,11 @@ index 0000000..d340f6a
 +    * labels: urgent
 +    */
 +}
-diff --git a/src/Dockerfile b/src/Dockerfile
+diff --git a/Dockerfile b/Dockerfile
 new file mode 100644
 index 0000000..d340f6a
 --- /dev/null
-+++ b/src/Dockerfile
++++ b/Dockerfile
 @@ -0,0 +1,4 @@
 +WORKDIR /app
 +ENV PYTHONPATH /app

--- a/tests/test_process_diff.py
+++ b/tests/test_process_diff.py
@@ -78,7 +78,7 @@ class IssueUrlInsertionTest(unittest.TestCase):
                      "Skipping because 'SKIP_PROCESS_DIFF_TEST' is 'true'")
     def test_url_insertion(self):
         self._setUp(['test_new.diff'])
-        self._standardTest(80)
+        self._standardTest(84)
 
     def test_line_numbering_with_deletions(self):
         self._setUp(['test_new_py.diff', 'test_edit_py.diff'])


### PR DESCRIPTION
When test_proces_diff processes `test_new.diff`, it creates the files that are referenced by the diff. If a file path contains a subdirectory, it fails to actually create the file, which in turn causes the test to fail. This PR cleans up `test_new.diff` such that no file is referenced within a subdirectory.

Updated number of expected passing tests to account for the additional tests which can run successfully now.

This is related to https://github.com/alstr/todo-to-issue-action/pull/266 and resolves the lingering issues that are referenced in comments there.