### PR TITLE
fix(GitHubClient): use html_url not web_url when listing ambiguous matches

### DIFF
--- a/GitHubClient.py
+++ b/GitHubClient.py
@@ -368,7 +368,7 @@ class GitHubClient(Client):
                         print(f'Skipping issue closure due to ambiguous match against multiple existing issues, shown below')
                         for x in self.existing_issues:
                             if x['title'] == search_title:
-                                print(f' {x["web_url"]}')
+                                print(f' {x["html_url"]}')
                         issue_number = None
                         break
                     issue_number = existing_issue['number']

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -1,0 +1,56 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+from GitHubClient import GitHubClient
+
+
+class CloseIssueAmbiguousMatchTest(unittest.TestCase):
+    """Regression tests for GitHubClient.close_issue's ambiguous-match path.
+
+    When a removed TODO matches more than one existing open issue (same title),
+    close_issue deliberately skips closure and prints each candidate so the run
+    log shows why. The existing issues come from the GitHub REST API
+    (GitHubClient._get_existing_issues), whose issue objects expose ``html_url``
+    (``web_url`` is a GitLab-only field). Printing the GitLab field crashed the
+    whole TODOs workflow with ``KeyError: 'web_url'``.
+    """
+
+    @staticmethod
+    def _client_with_issues(existing_issues):
+        # Bypass __init__ (it performs network calls in _get_existing_issues /
+        # _get_milestones); close_issue only needs existing_issues and the
+        # class-level max_issue_title_length.
+        client = GitHubClient.__new__(GitHubClient)
+        client.existing_issues = existing_issues
+        return client
+
+    def test_ambiguous_match_does_not_crash_and_skips_closure(self):
+        title = 'Remove auth-proxy when Cilium supports native forward auth'
+        # Two open issues share the title and carry only the GitHub field
+        # (html_url) — no web_url key, so the pre-fix code raised KeyError.
+        existing_issues = [
+            {'title': title, 'number': 11,
+             'html_url': 'https://github.com/o/r/issues/11'},
+            {'title': title, 'number': 22,
+             'html_url': 'https://github.com/o/r/issues/22'},
+        ]
+        client = self._client_with_issues(existing_issues)
+        removed_todo = SimpleNamespace(issue_number=None, title=title)
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            result = client.close_issue(removed_todo)
+
+        # Ambiguous match must skip closure (no issue closed -> None) ...
+        self.assertIsNone(result)
+        log = output.getvalue()
+        # ... and the diagnostic must list each ambiguous candidate by its URL.
+        self.assertIn('ambiguous match', log)
+        self.assertIn('https://github.com/o/r/issues/11', log)
+        self.assertIn('https://github.com/o/r/issues/22', log)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Not a new language definition, so the language-contribution template is omitted per its instructions. -->

## Description

`GitHubClient.close_issue()` crashes the entire action with `KeyError: 'web_url'` whenever a removed TODO matches **more than one** existing open issue with the same title.

On that ambiguous match the code intentionally skips closure and prints each candidate issue so the run log explains why:

```python
for x in self.existing_issues:
    if x['title'] == search_title:
        print(f' {x["web_url"]}')   # web_url is a GitLab field
```

`self.existing_issues` is populated from the **GitHub** REST API (`_get_existing_issues`), whose issue objects expose `html_url` — `web_url` is a GitLab-only field. So this diagnostic line raises `KeyError: 'web_url'` and takes the whole workflow down at the exact moment it was trying to report a non-fatal, skippable condition. It is the only `web_url` reference in the file.

## Fix

Print `html_url` instead of `web_url`, so the ambiguous-match path can log its candidates and continue as intended.

## Test

Adds `tests/test_github_client.py` — a network-free regression test that builds a `GitHubClient` via `__new__` (so it makes no API calls), seeds two same-title existing issues carrying only `html_url`, and asserts `close_issue` skips closure (returns `None`) and prints both candidate URLs without raising. It fails with `KeyError: 'web_url'` before the fix and passes after.

## Validation

- `python -m unittest tests.test_github_client` → passes (and fails as expected before the fix).
- Ran the full suite (`python -m unittest discover`). The new test passes. The only failure is a **pre-existing, environment-specific** error in the unrelated `test_process_diff` suite: macOS's BSD `patch` (Apple `patch 2.0`) rejects `tests/test_edit_py.diff`. It reproduces **identically on a pristine `master` checkout**, so it is a local `patch`-binary issue, not a code change — your Linux CI uses GNU `patch` and is unaffected. This change touches only `GitHubClient.py` and the new test file.

## Context

Surfaced downstream in [devantler-tech/actions#222](https://github.com/devantler-tech/actions/issues/222), where the bundled `create-issues-from-todos` action crashed on an ambiguous TODO match.

---

> 🤖 Prepared with AI assistance and submitted by @devantler. Happy to adjust the style or structure to your preferences.
